### PR TITLE
reset_template.m: Change default version of new projects to 0.0.1

### DIFF
--- a/reset_template.m
+++ b/reset_template.m
@@ -13,12 +13,12 @@ else
     error('Could not open CHANGELOG.md for writing.');
 end
 
-% Write "0.0.0" to version.txt
+% Write "0.0.1" to version.txt
 fid = fopen(versionPath, 'w');
 if fid ~= -1
-    fprintf(fid, '0.0.0\n');
+    fprintf(fid, '0.0.1\n');
     fclose(fid);
-    fprintf('version has been set to "0.0.0".\n');
+    fprintf('version has been set to "0.0.1".\n');
 else
     error('Could not open version.txt for writing.');
 end


### PR DESCRIPTION
Currently, `reset_template.m` resets the project version to 0.0.0, which is a bit strange and may not work well with release workflows etc. Change to 0.0.1.

Closes #16.