### PR TITLE
Sync mirror

### DIFF
--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.MATLAB_TEMPLATE_MIRROR_SSH_PRIVATE_KEY }}
       - name: Push changes to ImperialCollegeLondon/matlab-repo-init
         run: |
           # Clone and check out this repo

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -20,4 +21,4 @@ jobs:
           git remote add icl git@github.com:ImperialCollegeLondon/matlab-repo-init.git
 
           # Push all branches, overwriting if necessary
-          git push icl --all --force
+          git push --force --tags icl main

--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  mirror_repo:
+    if: github.repository == 'djmaxus/matlab-repo-init.git'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Push changes to ImperialCollegeLondon/matlab-repo-init
+        run: |
+          # Clone and check out this repo
+          git clone --mirror git@github.com:djmaxus/matlab-repo-init.git
+          cd matlab-repo-init.git
+
+          # Add repo in Imperial's org as remote
+          git remote add icl git@github.com:ImperialCollegeLondon/matlab-repo-init.git
+
+          # Push all branches, overwriting if necessary
+          git push icl --all --force

--- a/reset_template.m
+++ b/reset_template.m
@@ -34,6 +34,10 @@ else
     error('Could not open README.md for writing.');
 end
 
+% Delete unneeded workflow file
+syncMirrorWorkflowPath = fullfile(pwd, '.github/workflows/sync-mirror.yml');
+delete(syncMirrorWorkflowPath)
+
 % Create a figure for the UI
 hFig = figure('Name', 'Licenses to Keep', 'Position', [300, 300, 300, 150], 'MenuBar', 'none', 'NumberTitle', 'off');
 


### PR DESCRIPTION
This PR adds a CI workflow to push any changes made to this repo to the [fork on the ICL org](https://github.com/ImperialCollegeLondon/matlab-repo-init).

The problem with doing this is that by default the GitHub runner won't have the requisite permissions to push to a repository other than this one. I've got round this by using the [webfactory/ssh-agent](https://github.com/marketplace/actions/webfactory-ssh-agent) GitHub Action, but it does require manual setup (see the website for details).

In brief, you'll need to:

1. Generate a new ssh key locally
2. Add this key to your GitHub account so it's authorised to access both of the repos
3. Add a new repository secret called `SSH_PRIVATE_KEY` containing the contents of the private counterpart to the key you've just added to GitHub

(There are more details on the linked page.)

Let's hold off on merging this until everything's set up properly, just so we know it'll definitely work. If you're unsure about anything, please ask!

Closes #9.