### PR TITLE
Define Markdownlint GitHub Action and set

### DIFF
--- a/.github/workflows/markdownlint-cli2-action.yml
+++ b/.github/workflows/markdownlint-cli2-action.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
-      - develop
 
 jobs:
   lint:

--- a/.github/workflows/markdownlint-cli2-action.yml
+++ b/.github/workflows/markdownlint-cli2-action.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          fix: true       # Automatically fix fixable issues
-          globs: '**/*.md' # Target all Markdown files
+          fix: true       
+          globs: '**/*.md' 

--- a/.github/workflows/markdownlint-cli2-action.yml
+++ b/.github/workflows/markdownlint-cli2-action.yml
@@ -20,5 +20,7 @@ jobs:
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v18
         with:
-          fix: true       
-          globs: '**/*.md' 
+          fix: true
+          globs: |
+            **/*.md
+            !CHANGELOG.md

--- a/.github/workflows/markdownlint-cli2-action.yml
+++ b/.github/workflows/markdownlint-cli2-action.yml
@@ -1,0 +1,24 @@
+name: Markdownlint CLI2
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint:
+    name: Markdown Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          fix: true       # Automatically fix fixable issues
+          globs: '**/*.md' # Target all Markdown files


### PR DESCRIPTION
This Pull request adds a Markdownlinter to GitHub Actions to make sure `*.md ` files are formatted to standard. 

In particular, the following features were cofigured:
- Added `name` fields to the workflow and job for better identification in GitHub Actions UI
- Set workflow triggers to `main` and `develop` branches for both push and pull request events
- Enhanced step descriptions for clarity and easier debugging
- Ensured markdownlint CLI2 automatically fixes issues and targets all Markdown files

Closes #22. 