### PR TITLE
Fix `sync-mirror.yml` workflow

### DIFF
--- a/.github/workflows/sync-mirror.yml
+++ b/.github/workflows/sync-mirror.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   mirror_repo:
-    if: github.repository == 'djmaxus/matlab-repo-init.git'
+    if: github.repository == 'djmaxus/matlab-repo-init'
     runs-on: ubuntu-latest
     steps:
       - uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION
Currently this workflow is being skipped because the name of the repository that we're checking for is subtly wrong (there's an extra `.git` on the end of it). Fix this.

Closes #9.