### PR TITLE
Add link checker workflow to CI

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,20 @@
+name: Check links in Markdown files
+on:
+  schedule:
+    - cron: 0 0 * * 1   # midnight every Monday
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    name: Linkspector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review


### PR DESCRIPTION
This PR adds a GitHub Workflow to check whether links are valid, using an Action for a tool called Linkspector.

Closes #23.