### PR TITLE
fix(ci): explicit permissions for `buildtool`

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -4,6 +4,8 @@ on:
 
 jobs:
   buildtool:
+    permissions:
+      contents: read
     strategy:
       matrix:
         release: [R2023a, R2024b]


### PR DESCRIPTION
closes #135 