### PR TITLE
feat(doc): 📝 add CITATION file

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,10 @@
     "version": "0.2",
     "language": "en",
     "words": [
+        "djmaxus",
+        "Elizarev",
+        "Maksim",
+        "ORCID",
         "ruleset",
         "Rulesets",
         "Simulink"

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,4 @@ README.md                         export-ignore
 version.txt                       export-ignore
 test.m                            export-ignore
 .gitignore                        export-ignore
+CITATION.cff                      export-ignore

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,9 @@
         "action-patch",
         "init"
     ],
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/citation-file-format/citation-file-format/main/schema.json": [
+            "CITATION.cff"
+        ]
+    }
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+# https://github.com/citation-file-format/citation-file-format
+cff-version: 1.2.0
+type: software
+message: >-
+  If you use this software,
+  please put the copyright NOTICE.txt in your developments
+  and cite it using metadata in this file.
+# doi:
+title: "Template GitHub repository for open-source MATLAB"
+authors:
+  - &djmaxus
+    family-names: Elizarev
+    given-names: Maksim
+    alias: djmaxus
+    orcid: "https://orcid.org/0000-0002-5279-2877"
+    website: "https://djmaxus.dev"
+contact:
+  - *djmaxus
+keywords:
+  - MATLAB
+  - Template repository
+  - CI/CD
+  - Semantic Versioning
+  - License
+  - Release automation
+  - Github Actions
+  - github.io page
+license: BSD-3-Clause
+repository-code: "https://github.com/djmaxus/matlab-repo-init"
+url: "https://matlab-template.djmaxus.dev"
+abstract: "Wiki: https://github.com/djmaxus/matlab-repo-init/wiki"

--- a/CITATION.cff.template
+++ b/CITATION.cff.template
@@ -1,0 +1,8 @@
+# https://github.com/citation-file-format/citation-file-format
+cff-version: 1.2.0
+type: software
+message: >-
+  If you use this software,
+  please put the copyright NOTICE.txt in your developments
+  and cite it using metadata in this file.
+# doi:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Then, in _Settings — **Actions** — General_ of your repository:
 2. [x] _Allow GitHub Actions to create and approve pull requests_
 
 To enable repository webpage deployment:
+
 - [x] _Settings — **Pages** — Build and deployment — Source_ = **GitHub Actions**
 
 You can also import a pre-built [**ruleset**](.github/rules/main.json) to protect

--- a/test.m
+++ b/test.m
@@ -1,1 +1,1 @@
-init(1984, 'George Orwell', self_delete=false, reset_test=false);
+init(1984, 'George', 'Orwell', '1984', self_delete=false, reset_test=false);


### PR DESCRIPTION
Add CITATION.cff and update init script for metadata

Introduces a CITATION.cff file to provide citation metadata for the project, adhering to the citation-file-format standard.

Enhances the `init` script to support customizable project title and author details, enabling dynamic updates to metadata files like LICENSE and CITATION.

Improves maintainability by refactoring file reading logic into a reusable function and adding support for resetting the citation file template.

Closes #162 